### PR TITLE
Better describe Community section

### DIFF
--- a/app/src/frontend/building/data-containers/community.tsx
+++ b/app/src/frontend/building/data-containers/community.tsx
@@ -85,7 +85,7 @@ const CommunityView: React.FunctionComponent<CategoryViewProps> = (props) => {
             />
         </div>
 
-        <InfoBox>Can you help add information about public ownership of the building?</InfoBox>
+        <InfoBox>Can you help add information on community use of buildings?</InfoBox>
         <LogicalDataEntry
             slug='community_activities'
             title={dataFields.community_activities.title}

--- a/app/src/frontend/config/data-fields-config.ts
+++ b/app/src/frontend/config/data-fields-config.ts
@@ -541,7 +541,7 @@ export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
 
     community_activities: {
         category: Category.Community,
-        title: "Has the building ever been used for community activities?",
+        title: "Has this ever been used for community activities in the past?",
         tooltip: "E.g. youth club, place of worship, GP surgery, pub",
         example: true
     },


### PR DESCRIPTION
better describe section about community use

Finally something as easy as expected.

Here just to give @polly64 a chance to check

from #734 covers

>  Change 'Can you help add information about public ownership of the building' to 'Can you help add information on community use of buildings?'

>  Change 'Has the building ever been used for community activities' to 'Has this ever been used for community activities in the past'

![screen](https://user-images.githubusercontent.com/899988/151963410-af6badec-e8a5-4899-a9c4-b7cb0088d1eb.png)
