### PR TITLE
Current land use changes

### DIFF
--- a/app/map_styles/polygon.xml
+++ b/app/map_styles/polygon.xml
@@ -534,8 +534,12 @@
             <PolygonSymbolizer fill="#cccccc" />
         </Rule>
         <Rule>
-            <Filter>[current_landuse_order] = "Residential" and not ([current_landuse_group] = "Garden buildings") and not ([current_landuse_group] = "Hotels, boarding and guest houses") </Filter>
+            <Filter>[current_landuse_order] = "Residential" and not ([current_landuse_group] = "Garden buildings") and not ([current_landuse_group] = "Hotels, boarding and guest houses") and not ([current_landuse_verified])</Filter>
             <PolygonSymbolizer fill="#252aa6" />
+        </Rule>
+        <Rule>
+            <Filter>[current_landuse_order] = "Residential" and not ([current_landuse_group] = "Garden buildings") and not ([current_landuse_group] = "Hotels, boarding and guest houses") and ([current_landuse_verified])</Filter>
+            <PolygonSymbolizer fill="#7025a6" />
         </Rule>
         <Rule>
             <Filter>[current_landuse_order] = "Residential" and [current_landuse_group] = "Hotels, boarding and guest houses"</Filter>

--- a/app/src/api/config/dataFields.ts
+++ b/app/src/api/config/dataFields.ts
@@ -257,7 +257,15 @@ export const buildingAttributesConfig = valueType<DataFieldConfig>()({ /* eslint
         derivedEdit: true,
         verify: false,
     },
-
+    current_landuse_source: {
+        edit: true,
+    },
+    current_landuse_source_detail: {
+        edit: true,
+    },
+    current_landuse_link: {
+        edit: true,
+    },
     dynamics_has_demolished_buildings: {
         edit: true,
         verify: true

--- a/app/src/api/dataAccess/verify.ts
+++ b/app/src/api/dataAccess/verify.ts
@@ -74,6 +74,15 @@ export async function updateBuildingUserVerifiedAttribute(buildingId: number, us
                 [buildingId, userId, attribute, value]
             );
         }
+        if (attribute == 'current_landuse_group'){
+            await (db).none(
+                `UPDATE buildings
+                 SET current_landuse_verified = TRUE
+                 WHERE buildings.building_id = $1;"
+                 `,
+                 [buildingId]
+            );
+        }
     } catch(error) {
         console.error(error)
         if(error.detail?.includes('already exists')) {

--- a/app/src/api/dataAccess/verify.ts
+++ b/app/src/api/dataAccess/verify.ts
@@ -78,7 +78,7 @@ export async function updateBuildingUserVerifiedAttribute(buildingId: number, us
             await (db).none(
                 `UPDATE buildings
                  SET current_landuse_verified = TRUE
-                 WHERE buildings.building_id = $1;"
+                 WHERE buildings.building_id = $1;
                  `,
                  [buildingId]
             );
@@ -110,7 +110,7 @@ export async function removeBuildingUserVerifiedAttribute(buildingId: number, us
             await (db).none(
                 `UPDATE buildings
                  SET current_landuse_verified = FALSE
-                 WHERE buildings.building_id = $1;"
+                 WHERE buildings.building_id = $1;
                  `,
                  [buildingId]
             );

--- a/app/src/api/dataAccess/verify.ts
+++ b/app/src/api/dataAccess/verify.ts
@@ -106,6 +106,15 @@ export async function removeBuildingUserVerifiedAttribute(buildingId: number, us
             `,
             [buildingId, userId, attribute]
         );
+        if (attribute == 'current_landuse_group'){
+            await (db).none(
+                `UPDATE buildings
+                 SET current_landuse_verified = FALSE
+                 WHERE buildings.building_id = $1;"
+                 `,
+                 [buildingId]
+            );
+        }
     } catch(error) {
         throw new DatabaseError(error.detail);
     }

--- a/app/src/api/dataAccess/verify.ts
+++ b/app/src/api/dataAccess/verify.ts
@@ -96,6 +96,15 @@ export async function updateBuildingUserVerifiedAttribute(buildingId: number, us
 
 export async function removeBuildingUserVerifiedAttribute(buildingId: number, userId: string, attribute: string) : Promise<null> {
     try {
+        if (attribute == 'current_landuse_group'){
+            await (db).none(
+                `UPDATE buildings
+                 SET current_landuse_verified = FALSE
+                 WHERE buildings.building_id = $1;
+                 `,
+                 [buildingId]
+            );
+        }
         return await (db).none(
             `DELETE FROM
                 building_verification
@@ -106,15 +115,6 @@ export async function removeBuildingUserVerifiedAttribute(buildingId: number, us
             `,
             [buildingId, userId, attribute]
         );
-        if (attribute == 'current_landuse_group'){
-            await (db).none(
-                `UPDATE buildings
-                 SET current_landuse_verified = FALSE
-                 WHERE buildings.building_id = $1;
-                 `,
-                 [buildingId]
-            );
-        }
     } catch(error) {
         throw new DatabaseError(error.detail);
     }

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -52,13 +52,13 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
             onChange={props.onChange}
         />
         <SelectDataEntry
-            title={dataFields.date_source.title}
+            title={dataFields.current_landuse_source.title}
             slug="use_source"
             value={props.building.date_source}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
-            tooltip={dataFields.date_source.tooltip}
+            tooltip={dataFields.current_landuse_source.tooltip}
             placeholder=""
             options={[
                 "Expert knowledge of building",

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -73,7 +73,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
             ]}
             />
         <TextboxDataEntry
-            title={dataFields.date_source_detail.title}
+            title={dataFields.current_landuse_source_detail.title}
             slug="current_landuse_source_detail"
             value={props.building.current_landuse_source_detail}
             mode={props.mode}
@@ -82,7 +82,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
             tooltip={dataFields.current_landuse_source_detail.tooltip}
             />
         <MultiDataEntry
-            title={dataFields.date_link.title}
+            title={dataFields.current_landuse_link.title}
             slug="current_landuse_link"
             value={props.building.current_landuse_link}
             mode={props.mode}

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -56,7 +56,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
         <SelectDataEntry
             title={dataFields.current_landuse_source.title}
             slug="use_source"
-            value={props.current_landuse.source}
+            value={props.building.current_landuse_source}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
@@ -82,7 +82,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
         <TextboxDataEntry
             title={dataFields.date_source_detail.title}
             slug="use_source_detail"
-            value={props.current_landuse.source_detail}
+            value={props.building.current_landuse_source_detail}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
@@ -91,7 +91,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
         <MultiDataEntry
             title={dataFields.date_link.title}
             slug="use_link"
-            value={props.current_landuse.link}
+            value={props.building.current_landuse_link}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -51,6 +51,52 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
             copy={props.copy}
             onChange={props.onChange}
         />
+        <SelectDataEntry
+            title={dataFields.date_source.title}
+            slug="use_source"
+            value={props.building.date_source}
+            mode={props.mode}
+            copy={props.copy}
+            onChange={props.onChange}
+            tooltip={dataFields.date_source.tooltip}
+            placeholder=""
+            options={[
+                "Expert knowledge of building",
+                "Expert estimate from image",
+                "Survey of London",
+                "Pevsner Guides",
+                "Victoria County History",
+                "Local history publication",
+                "Other publication",
+                "National Heritage List for England",
+                "Other database or gazetteer",
+                "Historical map",
+                "Other archive document",
+                "Film/Video",
+                "Other website",
+                "Other"
+            ]}
+            />
+        <TextboxDataEntry
+            title={dataFields.date_source_detail.title}
+            slug="use_source_detail"
+            value={props.building.date_source_detail}
+            mode={props.mode}
+            copy={props.copy}
+            onChange={props.onChange}
+            tooltip={dataFields.date_source_detail.tooltip}
+            />
+        <MultiDataEntry
+            title={dataFields.date_link.title}
+            slug="use_link"
+            value={props.building.date_link}
+            mode={props.mode}
+            copy={props.copy}
+            onChange={props.onChange}
+            tooltip={dataFields.date_link.tooltip}
+            placeholder="https://..."
+            editableEntries={true}
+            />
     </Fragment>
 );
 const UseContainer = withCopyEdit(UseView);

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -63,19 +63,12 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
             tooltip={dataFields.current_landuse_source.tooltip}
             placeholder=""
             options={[
-                "Expert knowledge of building",
-                "Expert estimate from image",
-                "Survey of London",
-                "Pevsner Guides",
-                "Victoria County History",
-                "Local history publication",
-                "Other publication",
-                "National Heritage List for England",
-                "Other database or gazetteer",
-                "Historical map",
-                "Other archive document",
-                "Film/Video",
-                "Other website",
+                "Expert/personal knowledge of building",
+                "Online streetview image",
+                "Open planning authority dataset",
+                "Open property tax dataset",
+                "Open housing dataset",
+                "Open address dataset",
                 "Other"
             ]}
             />

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -72,16 +72,6 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
                 "Other"
             ]}
             />
-        // NOTE: This wasn't needed after all but will leave in case it becomes useful
-        // <TextboxDataEntry
-        //     title={dataFields.current_landuse_source_detail.title}
-        //     slug="current_landuse_source_detail"
-        //     value={props.building.current_landuse_source_detail}
-        //     mode={props.mode}
-        //     copy={props.copy}
-        //     onChange={props.onChange}
-        //     tooltip={dataFields.current_landuse_source_detail.tooltip}
-        //     />
         <MultiDataEntry
             title={dataFields.current_landuse_link.title}
             slug="current_landuse_link"

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -72,15 +72,16 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
                 "Other"
             ]}
             />
-        <TextboxDataEntry
-            title={dataFields.current_landuse_source_detail.title}
-            slug="current_landuse_source_detail"
-            value={props.building.current_landuse_source_detail}
-            mode={props.mode}
-            copy={props.copy}
-            onChange={props.onChange}
-            tooltip={dataFields.current_landuse_source_detail.tooltip}
-            />
+        // NOTE: This wasn't needed after all but will leave in case it becomes useful
+        // <TextboxDataEntry
+        //     title={dataFields.current_landuse_source_detail.title}
+        //     slug="current_landuse_source_detail"
+        //     value={props.building.current_landuse_source_detail}
+        //     mode={props.mode}
+        //     copy={props.copy}
+        //     onChange={props.onChange}
+        //     tooltip={dataFields.current_landuse_source_detail.tooltip}
+        //     />
         <MultiDataEntry
             title={dataFields.current_landuse_link.title}
             slug="current_landuse_link"

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -55,7 +55,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
         />
         <SelectDataEntry
             title={dataFields.current_landuse_source.title}
-            slug="use_source"
+            slug="current_landuse_source"
             value={props.building.current_landuse_source}
             mode={props.mode}
             copy={props.copy}
@@ -74,7 +74,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
             />
         <TextboxDataEntry
             title={dataFields.date_source_detail.title}
-            slug="use_source_detail"
+            slug="current_landuse_source_detail"
             value={props.building.current_landuse_source_detail}
             mode={props.mode}
             copy={props.copy}
@@ -83,7 +83,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
             />
         <MultiDataEntry
             title={dataFields.date_link.title}
-            slug="use_link"
+            slug="current_landuse_link"
             value={props.building.current_landuse_link}
             mode={props.mode}
             copy={props.copy}

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -79,7 +79,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
-            tooltip={dataFields.date_source_detail.tooltip}
+            tooltip={dataFields.current_landuse_source_detail.tooltip}
             />
         <MultiDataEntry
             title={dataFields.date_link.title}
@@ -88,7 +88,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
-            tooltip={dataFields.date_link.tooltip}
+            tooltip={dataFields.current_landuse_link.tooltip}
             placeholder="https://..."
             editableEntries={true}
             />

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -4,6 +4,8 @@ import InfoBox from '../../components/info-box';
 import { dataFields } from '../../config/data-fields-config';
 import DataEntry from '../data-components/data-entry';
 import { MultiDataEntry } from '../data-components/multi-data-entry/multi-data-entry';
+import SelectDataEntry from '../data-components/select-data-entry';
+import TextboxDataEntry from '../data-components/textbox-data-entry';
 import withCopyEdit from '../data-container';
 
 import { CategoryViewProps } from './category-view-props';

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -56,7 +56,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
         <SelectDataEntry
             title={dataFields.current_landuse_source.title}
             slug="use_source"
-            value={props.building.date_source}
+            value={props.current_landuse.source}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
@@ -82,7 +82,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
         <TextboxDataEntry
             title={dataFields.date_source_detail.title}
             slug="use_source_detail"
-            value={props.building.date_source_detail}
+            value={props.current_landuse.source_detail}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
@@ -91,7 +91,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => (
         <MultiDataEntry
             title={dataFields.date_link.title}
             slug="use_link"
-            value={props.building.date_link}
+            value={props.current_landuse.link}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}

--- a/app/src/frontend/config/category-maps-config.ts
+++ b/app/src/frontend/config/category-maps-config.ts
@@ -193,7 +193,8 @@ export const categoryMapsConfig: {[key in Category]: CategoryMapDefinition[]} = 
             elements: [
                 { color: '#e5050d', text: 'Mixed Use' },
                 { subtitle: 'Single use:'},
-                { color: '#252aa6', text: 'Residential' },
+                { color: '#252aa6', text: 'Residential (unverified)' },
+                { color: '#7025a6', text: 'Residential (verified)' },
                 { color: '#ff8c00', text: 'Retail' },
                 { color: '#f5f58f', text: 'Industry & Business' },
                 { color: '#73ccd1', text: 'Community Services' },

--- a/app/src/frontend/config/data-fields-config.ts
+++ b/app/src/frontend/config/data-fields-config.ts
@@ -199,6 +199,18 @@ export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
         tooltip: "Source for the current land use",
         example: "",
     },
+    current_landuse_source_detail: {
+        category: Category.LandUse,
+        title: "Source details",
+        tooltip: "References for current land use source (max 500 characters)",
+        example: "",
+    },
+    current_landuse_link: {
+        category: Category.LandUse,
+        title: "Text and Image Links",
+        tooltip: "URL for current land use reference",
+        example: ["", "", ""],
+    },
 
     building_attachment_form: {
         category: Category.Type,

--- a/app/src/frontend/config/data-fields-config.ts
+++ b/app/src/frontend/config/data-fields-config.ts
@@ -193,6 +193,12 @@ export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
         tooltip: "Land use Order as classified by [NLUD](https://www.gov.uk/government/statistics/national-land-use-database-land-use-and-land-cover-classification)",
         example: "",
     },
+    current_landuse_source: {
+        category: Category.LandUse,
+        title: "Source of information",
+        tooltip: "Source for the current land use",
+        example: "",
+    },
 
     building_attachment_form: {
         category: Category.Type,

--- a/app/src/frontend/config/data-fields-config.ts
+++ b/app/src/frontend/config/data-fields-config.ts
@@ -207,7 +207,7 @@ export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
     },
     current_landuse_link: {
         category: Category.LandUse,
-        title: "Text and Image Links",
+        title: "Source Links",
         tooltip: "URL for current land use reference",
         example: ["", "", ""],
     },

--- a/app/src/tiles/dataDefinition.ts
+++ b/app/src/tiles/dataDefinition.ts
@@ -150,7 +150,8 @@ const LAYER_QUERIES = {
         SELECT
             geometry_id,
             current_landuse_order,
-            current_landuse_group[1] as current_landuse_group
+            current_landuse_group[1] as current_landuse_group,
+            current_landuse_verified
         FROM
             buildings
         WHERE

--- a/migrations/015.bulk_data_sources.up.sql
+++ b/migrations/015.bulk_data_sources.up.sql
@@ -29,6 +29,7 @@ VALUES
 ('U030','Minerals','order',NULL,False),
 ('U040','Recreation And Leisure','order',NULL,True),
 ('U070','Residential','order',NULL,True),
+('U070','Residential (verified)','order',NULL,True),
 ('U090','Retail','order',NULL,True),
 ('U050','Transport','order',NULL,True),
 ('U130','Unused Land','order',NULL,False),

--- a/migrations/015.bulk_data_sources.up.sql
+++ b/migrations/015.bulk_data_sources.up.sql
@@ -29,7 +29,7 @@ VALUES
 ('U030','Minerals','order',NULL,False),
 ('U040','Recreation And Leisure','order',NULL,True),
 ('U070','Residential','order',NULL,True),
-('U070','Residential (verified)','order',NULL,True),
+('U070v','Residential (verified)','order',NULL,True),
 ('U090','Retail','order',NULL,True),
 ('U050','Transport','order',NULL,True),
 ('U130','Unused Land','order',NULL,False),

--- a/migrations/015.bulk_data_sources.up.sql
+++ b/migrations/015.bulk_data_sources.up.sql
@@ -29,7 +29,6 @@ VALUES
 ('U030','Minerals','order',NULL,False),
 ('U040','Recreation And Leisure','order',NULL,True),
 ('U070','Residential','order',NULL,True),
-('U070v','Residential (verified)','order',NULL,True),
 ('U090','Retail','order',NULL,True),
 ('U050','Transport','order',NULL,True),
 ('U130','Unused Land','order',NULL,False),

--- a/migrations/028.landuse-source.down.sql
+++ b/migrations/028.landuse-source.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE buildings DROP COLUMN IF EXISTS current_landuse_source;
+
+ALTER TABLE buildings DROP COLUMN IF EXISTS current_landuse_source_detail;
+
+ALTER TABLE buildings DROP COLUMN IF EXISTS current_landuse_link;

--- a/migrations/028.landuse-source.down.sql
+++ b/migrations/028.landuse-source.down.sql
@@ -3,3 +3,5 @@ ALTER TABLE buildings DROP COLUMN IF EXISTS current_landuse_source;
 ALTER TABLE buildings DROP COLUMN IF EXISTS current_landuse_source_detail;
 
 ALTER TABLE buildings DROP COLUMN IF EXISTS current_landuse_link;
+
+ALTER TABLE buildings DROP COLUMN IF NOT EXISTS current_landuse_verified;

--- a/migrations/028.landuse-source.up.sql
+++ b/migrations/028.landuse-source.up.sql
@@ -5,3 +5,5 @@ ALTER TABLE buildings ADD COLUMN IF NOT EXISTS current_landuse_source_detail var
 ALTER TABLE buildings ADD CONSTRAINT current_landuse_source_detail_len CHECK (length(current_landuse_source_detail) < 500);
 
 ALTER TABLE buildings ADD COLUMN IF NOT EXISTS current_landuse_link text[];
+
+ALTER TABLE buildings ADD COLUMN IF NOT EXISTS current_landuse_verified BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/028.landuse-source.up.sql
+++ b/migrations/028.landuse-source.up.sql
@@ -7,3 +7,8 @@ ALTER TABLE buildings ADD CONSTRAINT current_landuse_source_detail_len CHECK (le
 ALTER TABLE buildings ADD COLUMN IF NOT EXISTS current_landuse_link text[];
 
 ALTER TABLE buildings ADD COLUMN IF NOT EXISTS current_landuse_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE buildings as b
+SET current_landuse_verified = TRUE
+FROM building_verification as v
+WHERE b.building_id = v.building_id;

--- a/migrations/028.landuse-source.up.sql
+++ b/migrations/028.landuse-source.up.sql
@@ -11,4 +11,5 @@ ALTER TABLE buildings ADD COLUMN IF NOT EXISTS current_landuse_verified BOOLEAN 
 UPDATE buildings as b
 SET current_landuse_verified = TRUE
 FROM building_verification as v
-WHERE b.building_id = v.building_id;
+WHERE b.building_id = v.building_id
+AND v.attribute = 'current_landuse_group';

--- a/migrations/028.landuse-source.up.sql
+++ b/migrations/028.landuse-source.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE buildings ADD COLUMN IF NOT EXISTS current_landuse_source varchar;
+ALTER TABLE buildings ADD CONSTRAINT buildings_current_landuse_source_len CHECK (length(current_landuse_source) < 150);
+
+ALTER TABLE buildings ADD COLUMN IF NOT EXISTS current_landuse_source_detail varchar;
+ALTER TABLE buildings ADD CONSTRAINT current_landuse_source_detail_len CHECK (length(current_landuse_source_detail) < 500);
+
+ALTER TABLE buildings ADD COLUMN IF NOT EXISTS current_landuse_link text[];


### PR DESCRIPTION
Closes #724

### Testing

- [x] Ensure working correctly on this branch locally
- [x] Pull branch to staging and ask for Polly Hudson review. Steps:
    - Pull branch
    - Run migration 028

### TODO

Make it so that when the verification button is clicked, a "verified" boolean column on the buildings table is set to True (this would need to specifically be `current_use_verified` as oppose to `verified`) as well as the entry in building_verification table being made, then set the colour rule in `polygon.xml` to be dependent on this. This is in `verify.ts` - this updates the `building_verification` table, regardless of which verify button was pushed, so there can be multiple entries per building. It differentiates which button was clicked via the `attribute` column, for which we are interested in `current_landuse_group`.

- [x] Make it so the verify button changes the colour
- [x] Add the new colour to the legend
- [x] Make it so un-verifying reverts the colour
- [x] ~~Temp~~ update migration script to change the existing entries