### PR TITLE
Rename "Streetscape" to "Street Context"

### DIFF
--- a/app/src/frontend/config/categories-config.ts
+++ b/app/src/frontend/config/categories-config.ts
@@ -109,7 +109,7 @@ export const categoriesConfig: {[key in Category]: CategoryDefinition} = {
     [Category.Streetscape]: {
         inactive: true,
         slug: 'streetscape',
-        name: 'Streetscape',
+        name: 'Street Context',
         aboutUrl: 'https://pages.colouring.london/greenery',
         intro: "What's the building's context? Coming soon…",
     },

--- a/app/src/frontend/config/category-maps-config.ts
+++ b/app/src/frontend/config/category-maps-config.ts
@@ -219,7 +219,7 @@ export const categoryMapsConfig: {[key in Category]: CategoryMapDefinition[]} = 
     [Category.Streetscape]: [{
         mapStyle: undefined,
         legend: {
-            title: 'Streetscape',
+            title: 'Street Context',
             elements: []
         },
     }],


### PR DESCRIPTION
Hi @tomalrussell @matkoniecz could either of you help with this? It seems like it should be a simple thing, but I'm not sure how to edit the category names at the front end, is there a somewhere in the codebase where the displayed names can be edited?

e.g. it should look like this after the change:
<img width="1908" alt="Screenshot 2022-06-24 at 10 14 31" src="https://user-images.githubusercontent.com/5486164/175505741-ab05661f-861f-4032-acd4-a0caa1765010.png">

