### PR TITLE
upgrade mini-css-extract-plugin

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -64,7 +64,7 @@
         "eslint-plugin-jest": "^24.3.5",
         "eslint-plugin-react": "^7.23.2",
         "html-webpack-plugin": "^4.5.2",
-        "mini-css-extract-plugin": "^0.9.0",
+        "mini-css-extract-plugin": "^0.12.0",
         "postcss": "^8.2.4",
         "razzle": "^4.0.4",
         "razzle-dev-utils": "^4.0.4",
@@ -10855,9 +10855,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
-      "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.12.0.tgz",
+      "integrity": "sha512-z6PQCe9rd1XUwZ8gMaEVwwRyZlrYy8Ba1gRjFP5HcV51HkXX+XlwZ+a1iAYTjSYwgNBXoNR7mhx79mDpOn5fdw==",
       "dev": true,
       "dependencies": {
         "loader-utils": "^1.1.0",
@@ -10868,8 +10868,12 @@
       "engines": {
         "node": ">= 6.9.0"
       },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
       "peerDependencies": {
-        "webpack": "^4.4.0"
+        "webpack": "^4.4.0 || ^5.0.0"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/ajv": {
@@ -28489,9 +28493,9 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
-      "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.12.0.tgz",
+      "integrity": "sha512-z6PQCe9rd1XUwZ8gMaEVwwRyZlrYy8Ba1gRjFP5HcV51HkXX+XlwZ+a1iAYTjSYwgNBXoNR7mhx79mDpOn5fdw==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-jest": "^24.3.5",
     "eslint-plugin-react": "^7.23.2",
     "html-webpack-plugin": "^4.5.2",
-    "mini-css-extract-plugin": "^0.9.0",
+    "mini-css-extract-plugin": "^0.12.0",
     "postcss": "^8.2.4",
     "razzle": "^4.0.4",
     "razzle-dev-utils": "^4.0.4",


### PR DESCRIPTION
following setup-dev-environment.md was running into problem of broken dependencies with webpack4 and webpack5 being required at the same time
updating this dependency is safe according to https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/CHANGELOG.md#0120-2020-10-07 changelog

tested on 18.04, not thoroughly but this change should be fairly safe - before change following https://github.com/colouring-cities/colouring-london/blob/master/docs/setup-dev-environment.md failed, after this change it now works

@traveller195 @gpanag - is it now working, at least on Ubuntu 18.04 LTS (EOL April 2023)? If yes - is it maybe working on 20.04?

And big thanks for a report!