### PR TITLE
Change "Building name" text box to "Building information (link)" in Location category

### DIFF
--- a/app/src/frontend/building/data-containers/age.tsx
+++ b/app/src/frontend/building/data-containers/age.tsx
@@ -169,6 +169,7 @@ const AgeView: React.FunctionComponent<CategoryViewProps> = (props) => {
                 tooltip={dataFields.date_link.tooltip}
                 placeholder="https://..."
                 editableEntries={true}
+                isUrl={true}
                 />
             <Verification
                 slug="date_link"

--- a/app/src/frontend/building/data-containers/location.tsx
+++ b/app/src/frontend/building/data-containers/location.tsx
@@ -61,7 +61,7 @@ const LocationView: React.FunctionComponent<CategoryViewProps> = (props) => (
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
-            
+            maxLength={30}
             />
         <Verification
             slug="location_street"
@@ -79,6 +79,7 @@ const LocationView: React.FunctionComponent<CategoryViewProps> = (props) => (
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
+            maxLength={30}
             />
         <Verification
             slug="location_line_two"

--- a/app/src/frontend/building/data-containers/location.tsx
+++ b/app/src/frontend/building/data-containers/location.tsx
@@ -24,7 +24,7 @@ const LocationView: React.FunctionComponent<CategoryViewProps> = (props) => (
             onChange={props.onChange}
             tooltip={dataFields.location_name.tooltip}
             placeholder="https://..."
-            
+            isUrl={true}
             />
         <Verification
             slug="location_name"

--- a/app/src/frontend/building/data-containers/location.tsx
+++ b/app/src/frontend/building/data-containers/location.tsx
@@ -23,7 +23,7 @@ const LocationView: React.FunctionComponent<CategoryViewProps> = (props) => (
             copy={props.copy}
             onChange={props.onChange}
             tooltip={dataFields.location_name.tooltip}
-            placeholder="Building name (if any)"
+            placeholder="https://..."
             
             />
         <Verification

--- a/app/src/frontend/building/data-containers/team.tsx
+++ b/app/src/frontend/building/data-containers/team.tsx
@@ -121,6 +121,7 @@ const TeamView: React.FunctionComponent<CategoryViewProps> = (props) => {
               tooltip={dataFields.developer_source_link.tooltip}
               placeholder="https://..."
               editableEntries={true}
+              isUrl={true}
               />
           <Verification
               slug="developer_source_link"
@@ -159,6 +160,7 @@ const TeamView: React.FunctionComponent<CategoryViewProps> = (props) => {
               tooltip={dataFields.designers_source_link.tooltip}
               placeholder="https://..."
               editableEntries={true}
+              isUrl={true}
               />
           <Verification
               slug="designers_source_link"
@@ -214,6 +216,7 @@ const TeamView: React.FunctionComponent<CategoryViewProps> = (props) => {
               tooltip={dataFields.awards_source_link.tooltip}
               placeholder="https://..."
               editableEntries={true}
+              isUrl={true}
               />
           <Verification
               slug="awards_source_link"
@@ -253,6 +256,7 @@ const TeamView: React.FunctionComponent<CategoryViewProps> = (props) => {
            onChange={props.onChange}
            placeholder="https://..."
            editableEntries={true}
+           isUrl={true}
            />
        <Verification
            slug="builder_source_link"
@@ -289,6 +293,7 @@ const TeamView: React.FunctionComponent<CategoryViewProps> = (props) => {
            onChange={props.onChange}
            placeholder="https://..."
            editableEntries={true}
+           isUrl={true}
            />
        <Verification
            slug="other_team_source_link"

--- a/app/src/frontend/building/data-containers/use.tsx
+++ b/app/src/frontend/building/data-containers/use.tsx
@@ -148,6 +148,7 @@ const UseView: React.FunctionComponent<CategoryViewProps> = (props) => {
                 tooltip={dataFields.current_landuse_link.tooltip}
                 placeholder="https://..."
                 editableEntries={true}
+                isUrl={true}
                 />
             <Verification
                 slug="current_landuse_link"

--- a/app/src/frontend/config/data-fields-config.ts
+++ b/app/src/frontend/config/data-fields-config.ts
@@ -118,9 +118,9 @@ export const buildingUserFields = {
 export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
     location_name: {
         category: Category.Location,
-        title: "Building Name",
-        tooltip: "May not be needed for many buildings.",
-        example: "The Cruciform",
+        title: "Building information (link)",
+        tooltip: "Link to a website with information on the building, not needed for most.",
+        example: "https://en.wikipedia.org/wiki/Palace_of_Westminster",
     },
     location_number: {
         category: Category.Location,


### PR DESCRIPTION
See comments at end of #849 

- Limits the link box to being a url only
- Also applies this limit to other fields that were missed out before in Team and Age categories