### PR TITLE
Tweak colour for mineral buildings

### DIFF
--- a/app/map_styles/polygon.xml
+++ b/app/map_styles/polygon.xml
@@ -601,7 +601,7 @@
         </Rule>
         <Rule>
             <Filter>[current_landuse_order] = "Minerals"</Filter>
-            <PolygonSymbolizer fill="#53f5dd" />
+            <PolygonSymbolizer fill="#45cce3" />
         </Rule>
         <Rule>
             <Filter>[current_landuse_order] = "Unclassified, presumed non-residential"</Filter>

--- a/app/src/frontend/config/category-maps-config.ts
+++ b/app/src/frontend/config/category-maps-config.ts
@@ -229,7 +229,7 @@ export const categoryMapsConfig: {[key in Category]: CategoryMapDefinition[]} = 
                 { color: '#cccccc', text: 'Utilities & Infrastructure' },
                 { color: '#898944', text: 'Defence' },
                 { color: '#fa667d', text: 'Agriculture' },
-                { color: '#53f5dd', text: 'Minerals' },
+                { color: '#45cce3', text: 'Minerals' },
                 { color: '#ffffff', text: 'Vacant & Derelict' },
                 { color: '#6c6f8e', text: 'Unclassified, presumed non-residential' }
             ]


### PR DESCRIPTION
was almost exactly the same as an active outline

found during testing of colour styles for planning - and it turned out that offending colour was exactly the same as in Land Use