### PR TITLE
Make status title less confusing

### DIFF
--- a/app/src/frontend/building/data-components/planning-data-entry.tsx
+++ b/app/src/frontend/building/data-components/planning-data-entry.tsx
@@ -99,7 +99,7 @@ const PlanningDataOfficialDataEntry: React.FC<PlanningDataOfficialDataEntryProps
         <Fragment>
         <InfoBox type='success'>
             <Fragment>
-                <div><b>Current planning application status for this site:</b> <StatusInfo 
+                <div><b>Planning application status for this site:</b> <StatusInfo
                   statusBeforeAliasing={item["status_before_aliasing"]}
                   status={item["status"]}
                 /></div>


### PR DESCRIPTION
especially for historic data 'current' was confusing also it is shorter and easier to read
fixes #1013