### PR TITLE
adjust flex to work better with long titles

### DIFF
--- a/app/src/frontend/building/container-header.css
+++ b/app/src/frontend/building/container-header.css
@@ -17,7 +17,7 @@
 
 .section-header .h2 {
     display: inline-block;
-    flex-basis: 150px;
+    flex-basis: 200px;
     flex-shrink: 0;
     flex-grow: 1;
     margin: 0.75rem 0 0.5em 0.1em;
@@ -33,7 +33,8 @@
 
 .section-header .section-header-actions {
     display: inline-block;
-    flex-basis: 400px;
+    flex-basis: 220px;
+    flex-shrink: 0;
     display: flex;
     flex-flow: row wrap;
     align-items: center;


### PR DESCRIPTION
![screen07](https://user-images.githubusercontent.com/899988/211588786-cb07f22d-010b-420c-8d8d-8e4edddec8f3.png)
![screen06](https://user-images.githubusercontent.com/899988/211588797-d9ebe743-6d73-4491-b157-a0ac072c4fff.png)

tested with current troublesome ones, and with even longer ones (I assumed that in case of extra-long titles it would be better to wrap title than action labels)