### PR TITLE
more aggressive caching

### DIFF
--- a/app/src/tiles/rendererDefinition.ts
+++ b/app/src/tiles/rendererDefinition.ts
@@ -32,14 +32,10 @@ let shouldCacheFn: (t: TileParams) => boolean;
 if(!allLayersCacheSwitch) {
     shouldCacheFn = t => false;
 } else if(dataLayersCacheSwitch) {
-    // cache age data and base building outlines for more zoom levels than other layers
-    shouldCacheFn = ({ tileset, z }: TileParams) =>
-        (tileset === 'date_year' && z <= 16) ||
-        (['base_light', 'base_night', 'base_night_outlines', 'base_boroughs'].includes(tileset) && z <= 17) ||
-        z <= 13;
+    shouldCacheFn = ({ tileset, z }: TileParams) => z <= 18;
 } else {
     shouldCacheFn = ({ tileset, z }: TileParams) =>
-        ['base_light', 'base_night', 'base_night_outlines', 'base_boroughs'].includes(tileset) && z <= 17;
+        ['base_light', 'base_night', 'base_night_outlines', 'base_boroughs'].includes(tileset) && z <= 18;
 }
 
 const tileCache = new TileCache(


### PR DESCRIPTION
in tests it seems confirmed that caching noticeably improves performance (Polly noticed that age layer is noticeably faster without being aware that it is cached more aggressively, in testing in general all layers benefit from caching even at zoom level 18 for relatively minor storage cost and differences in the first use performance that are basically not possible to measure (or at least I failed to measure them)

caching will be especially important as more people will use the site and will help reduce server costs

see also #1062 proposing further simplification of this code